### PR TITLE
add nao_pose/launch/pose_manager.launch

### DIFF
--- a/pepper_bringup/launch/pepper.launch
+++ b/pepper_bringup/launch/pepper.launch
@@ -7,7 +7,7 @@
   <include file="$(find naoqi_driver)/launch/naoqi_driver.launch">
     <arg name="force_python" value="$(arg force_python)" />
   </include>
-
+  <include file="$(find nao_pose)/launch/pose_manager.launch" />
   <include file="$(find pepper_sensors)/launch/sonar.launch" />
   <include file="$(find pepper_sensors)/launch/laser.launch" />
   <include file="$(find pepper_sensors)/launch/camera.launch" ns="camera/depth" >


### PR DESCRIPTION
Like nao_bringup/launch/nao_full.launch, I added nao_pose/launch/pose_manager.launch to pepper.launch.

Firstly I executed `rosluanch jsk_pepper_startup jsk_pepper_startup.launch`.
Then, I executed these three commands:

```
roscd peppereus
roseus pepper-interface.l
pepper-init
```

I found joint_trajectory action server failed (warning message is below).

```
;; extending gcstack 0x6728290[32738] --> 0x7c93980[65476] top=7fe1
[ WARN] [1433162659.695376752]: [joint_trajectory] action server is not found
[ WARN] [1433162659.695472650]:      goal=0, cancel=0, feedback=0, result=0
[ WARN] [1433162659.695530702]: #<controller-action-client #X735f5c8 joint_trajectory> is not respond, pepper-interface is disabled
```

When I executed  `rostopic info /joint_trajectory/status`, the result was as follows:

```
 Type: actionlib_msgs/GoalStatusArray

Publishers: None

Subscribers: 
 * /pepper_1433170081822103285 (http://192.168.97.25:48247/)
```

After I added pose_manager.launch, the result of  `rostopic info /joint_trajectory/status` was as follows:

```
Type: actionlib_msgs/GoalStatusArray

Publishers: 
 * /pose_controller (http://192.168.97.25:44509/)

Subscribers: 
 * /pepper_1433170081822103285 (http://192.168.97.25:48247/)
 * /greeting_1433171587533658641 (http://192.168.97.25:45389/)
 * /greeting_1433171622367680247 (http://192.168.97.25:40239/)
 * /greeting_1433171725085424291 (http://192.168.97.25:39784/)
 * /pose_manager (http://192.168.97.25:55685/)
```

(/greeting is my original node, so it can be ignored.)
