### PR TITLE
Add a missing dependency

### DIFF
--- a/pepper_description/package.xml
+++ b/pepper_description/package.xml
@@ -9,6 +9,7 @@
   <license>Apache 2.0</license>
 
   <run_depend>robot_state_publisher</run_depend>
+  <run_depend>pepper_meshes</run_depend>
   <run_depend>urdf</run_depend>
   <run_depend>xacro</run_depend>
 


### PR DESCRIPTION
Without meshes package I couldn't run moveit.

```
$ roslaunch pepper_moveit_config demo.launch 
:
[ INFO] [1447640832.052623649]: Loading robot model 'JulietteY20MP'...
[rospack] Error: package 'pepper_meshes' not found
[librospack]: error while executing command
[ERROR] [1447640832.217624613]: Error retrieving file [package://pepper_meshes/meshes/1.0/Torso_0.10.stl]: Package [pepper_meshes] does not exist
[ INFO] [1447640832.294411368]: Stereo is NOT SUPPORTED
[ INFO] [1447640832.294499228]: OpenGl version: 3 (GLSL 1.3).
[rospack] Error: package 'pepper_meshes' not found
```
