### PR TITLE
[pepper_bringup/package.xml] add naoqi_pose, naoqi_driver_py to run_depend

### DIFF
--- a/pepper_bringup/CMakeLists.txt
+++ b/pepper_bringup/CMakeLists.txt
@@ -13,3 +13,8 @@ install(DIRECTORY config
 
 install(DIRECTORY launch
    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(catkin REQUIRED COMPONENTS rostest roslaunch)
+  roslaunch_add_file_check(launch)
+endif()

--- a/pepper_bringup/package.xml
+++ b/pepper_bringup/package.xml
@@ -9,8 +9,13 @@
   <license>Apache 2.0</license>
 
   <run_depend>naoqi_driver</run_depend>
+  <run_depend>naoqi_pose</run_depend>
   <run_depend>pepper_description</run_depend>
+  <run_depend>naoqi_driver_py</run_depend>
   <run_depend>pepper_sensors_py</run_depend>
+
+  <test_depend>rostest</test_depend>
+  <test_depend>roslaunch</test_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
 


### PR DESCRIPTION
- [pepper_bringup/package.xml] add naoqi_pose, naoqi_driver_py to run_depend
- [pepper_bringup/CMakeLists.txt] add test for launch file validation

Now you can check launch file validity.
e.g.  typo in launch file, missing close tag, missing to add dependencies to run_depend by
`catkin run_tests pepper_bringup -i -v`
