### PR TITLE
Add depth camera

### DIFF
--- a/pepper_description/urdf/pepper1.0_generated_urdf/pepperGazebo.xacro
+++ b/pepper_description/urdf/pepper1.0_generated_urdf/pepperGazebo.xacro
@@ -522,6 +522,43 @@
       </sensor>
     </gazebo>
 
+    <gazebo reference="CameraDepth_frame">
+      <sensor type="depth" name="CameraDepth_frame_sensor">
+        <always_on>true</always_on>
+        <update_rate>20.0</update_rate>
+        <camera>
+          <horizontal_fov>${58.0*3.14159265359/180.0}</horizontal_fov>
+          <image>
+            <format>B8G8R8</format>
+            <width>320</width>
+            <height>240</height>
+          </image>
+          <clip>
+            <near>0.4</near>
+            <far>8.0</far>
+          </clip>
+        </camera>
+        <plugin name="CameraDepth_frame_controller" filename="libgazebo_ros_openni_kinect.so">
+          <alwaysOn>true</alwaysOn>
+          <updateRate>20.0</updateRate>
+          <cameraName>pepper_robot/camera</cameraName>
+          <imageTopicName>ir/image_raw</imageTopicName>
+          <cameraInfoTopicName>depth/camera_info</cameraInfoTopicName>
+          <depthImageTopicName>depth/image_raw</depthImageTopicName>
+          <pointCloudTopicName>depth/points</pointCloudTopicName>
+          <frameName>CameraDepth_optical_frame</frameName>
+          <pointCloudCutoff>0.4</pointCloudCutoff>
+          <pointCloudCutoffMax>8.0</pointCloudCutoffMax>
+          <!-- <distortionK1>0.00000001</distortionK1>
+          <distortionK2>0.00000001</distortionK2>
+          <distortionK3>0.00000001</distortionK3>
+          <distortionT1>0.00000001</distortionT1>
+          <distortionT2>0.00000001</distortionT2> -->
+        </plugin>
+      </sensor>
+    </gazebo>
+
+
 <!-- 
     BUMPERS
 


### PR DESCRIPTION
It's not ideal as it also publishes a BGR camera which I named _ir_ but either using _libgazebo_ros_openni_kinect.so_ or _libgazebo_ros_depth_camera.so_ the same thing happened, and in the case of the last plugin the camera_info was not being published somehow.

I also don't know which one is the real topic name. But I hope this is useful to someone/a good start point.
![screenshot from 2017-02-14 17 10 49](https://cloud.githubusercontent.com/assets/1721716/22917668/3323434c-f2da-11e6-8d59-25fb786b6d7d.png)
